### PR TITLE
Lua Object improvements

### DIFF
--- a/core/camera.c
+++ b/core/camera.c
@@ -96,6 +96,27 @@ Camera *camera_new(void) {
     return c;
 }
 
+Camera *camera_new_copy(const Camera *c) {
+    Camera *copy = camera_new();
+    transform_copy(copy->view, c->view);
+    copy->mode = c->mode;
+    copy->fov = c->fov;
+    copy->width = c->width;
+    copy->height = c->height;
+    copy->nearPlane = c->nearPlane;
+    copy->farPlane = c->farPlane;
+    copy->targetX = c->targetX;
+    copy->targetY = c->targetY;
+    copy->targetWidth = c->targetWidth;
+    copy->targetHeight = c->targetHeight;
+    copy->color = c->color;
+    copy->layers = c->layers;
+    copy->viewOrder = c->viewOrder;
+    copy->enabled = c->enabled;
+
+    return copy;
+}
+
 void camera_release(Camera *c) {
     transform_release(c->view);
 }

--- a/core/camera.h
+++ b/core/camera.h
@@ -27,6 +27,7 @@ typedef enum {
 } ProjectionMode;
 
 Camera *camera_new(void);
+Camera *camera_new_copy(const Camera *c);
 void camera_release(Camera *c);
 void camera_free(Camera *c);
 

--- a/core/light.c
+++ b/core/light.c
@@ -47,6 +47,23 @@ Light *light_new(void) {
     return l;
 }
 
+Light *light_new_copy(const Light *l) {
+    Light *copy = light_new();
+    transform_copy(copy->transform, l->transform);
+    *copy->color = *l->color;
+    copy->type = l->type;
+    copy->range = l->range;
+    copy->hardness = l->hardness;
+    copy->angle = l->angle;
+    copy->intensity = l->intensity;
+    copy->priority = l->priority;
+    copy->layers = l->layers;
+    copy->enabled = l->enabled;
+    copy->shadow = l->shadow;
+
+    return copy;
+}
+
 Light *light_new_point(const float radius, const float hardness, const uint8_t priority) {
     Light *l = light_new();
 

--- a/core/light.h
+++ b/core/light.h
@@ -27,6 +27,7 @@ typedef enum {
 } LightType;
 
 Light *light_new(void);
+Light *light_new_copy(const Light *l);
 Light *light_new_point(const float radius, const float hardness, const uint8_t priority);
 Light *light_new_spot(const float range,
                       const float angle,

--- a/core/mesh.c
+++ b/core/mesh.c
@@ -72,8 +72,8 @@ Mesh* mesh_new(void) {
 }
 
 Mesh* mesh_new_copy(const Mesh* m) {
-    Mesh* copy = (Mesh*)malloc(sizeof(Mesh));
-    copy->transform = transform_new_with_ptr(MeshTransform, (void*)(uintptr_t)m, &_mesh_void_free);
+    Mesh* copy = mesh_new();
+    transform_copy(copy->transform, m->transform);
 
     copy->vb = (Vertex*)malloc(m->vbCount * sizeof(Vertex));
     memcpy(copy->vb, m->vb, m->vbCount * sizeof(Vertex));

--- a/core/quad.c
+++ b/core/quad.c
@@ -87,6 +87,27 @@ Quad *quad_new(void) {
     return q;
 }
 
+Quad *quad_new_copy(const Quad* q) {
+    Quad *copy = quad_new();
+    transform_copy(copy->transform, q->transform);
+    quad_set_data(copy, q->data, q->size); // TODO: use registry (see lua_quad)
+    copy->width = q->width;
+    copy->height = q->height;
+    copy->anchorX = q->anchorX;
+    copy->anchorY = q->anchorY;
+    copy->tilingU = q->tilingU;
+    copy->tilingV = q->tilingV;
+    copy->offsetU = q->offsetU;
+    copy->offsetV = q->offsetV;
+    copy->cutout = q->cutout;
+    copy->layers = q->layers;
+    copy->flags = q->flags;
+    copy->sortOrder = q->sortOrder;
+    *copy->rgba = *q->rgba;
+
+    return copy;
+}
+
 void quad_release(Quad *q) {
     transform_release(q->transform);
 }

--- a/core/quad.h
+++ b/core/quad.h
@@ -19,6 +19,7 @@ extern "C" {
 typedef struct _Quad Quad;
 
 Quad *quad_new(void);
+Quad *quad_new_copy(const Quad* q);
 void quad_release(Quad *q);
 void quad_free(Quad *q); // called in transform_release, does not free transform
 

--- a/core/scene.c
+++ b/core/scene.c
@@ -404,7 +404,7 @@ void scene_add_map(Scene *sc, Shape *map) {
         transform_remove_parent(sc->map, true);
     }
 
-    sc->map = shape_get_root_transform(map);
+    sc->map = shape_get_transform(map);
     transform_set_parent(sc->map, sc->root, true);
 
 #if DEBUG_SCENE_EXTRALOG
@@ -825,7 +825,7 @@ Block *scene_cast_ray_shape_only(Scene *sc,
         float3 ldf = {hit.blockCoords.x, hit.blockCoords.y, hit.blockCoords.z};
         const FACE_INDEX_INT_T face = ray_impacted_block_face(&localImpact, &ldf);
 
-        hit.hitTr = shape_get_root_transform(sh);
+        hit.hitTr = shape_get_transform(sh);
         hit.type = Hit_Block;
         hit.faceTouched = face;
     }

--- a/core/scene.h
+++ b/core/scene.h
@@ -83,7 +83,8 @@ CollisionCoupleStatus scene_register_collision_couple(Scene *sc,
 
 /// Toggle this flag when using scene recursion where an external callback w/ the ability to remove
 /// transforms is called. Transforms removal will be delayed until the flag is turned OFF
-void scene_toggle_recursion_lock(Scene *sc, const bool toggle);
+/// @returns false if maximum nested recursion count is reached
+bool scene_toggle_recursion_lock(Scene *sc, const bool toggle);
 
 // MARK: - Physics -
 

--- a/core/serialization.c
+++ b/core/serialization.c
@@ -99,7 +99,7 @@ Shape *assets_get_root_shape(DoublyLinkedList *list, bool remove) {
         Asset *r = (Asset *)doubly_linked_list_node_pointer(n);
         if (r->type == AssetType_Shape) {
             Shape *s = (Shape *)r->ptr;
-            if (transform_get_parent(shape_get_root_transform(s)) == NULL) {
+            if (transform_get_parent(shape_get_transform(s)) == NULL) {
                 if (remove) {
                     free(r);
                     doubly_linked_list_delete_node(list, n);

--- a/core/serialization_v5.c
+++ b/core/serialization_v5.c
@@ -496,7 +496,7 @@ uint32_t chunk_v5_read_shape(Stream *s,
                 shapeSizeRead = true;
 
                 // size is known, now is a good time to create the shape
-                *shape = shape_make_2(shapeSettings->isMutable);
+                *shape = shape_new_2(shapeSettings->isMutable);
                 if (serializedPalette != NULL) {
                     shape_set_palette(*shape, serializedPalette, false);
                 } else {

--- a/core/serialization_v6.c
+++ b/core/serialization_v6.c
@@ -557,7 +557,7 @@ bool chunk_v6_write_shape(FILE *fd,
     shapeParentId = *shapeId;
     (*shapeId)++;
 
-    DoublyLinkedListNode *n = transform_get_children_iterator(shape_get_root_transform(shape));
+    DoublyLinkedListNode *n = transform_get_children_iterator(shape_get_transform(shape));
     Transform *child = NULL;
 
     while (n != NULL) {
@@ -991,7 +991,7 @@ uint32_t chunk_v6_read_shape(Stream *s,
                 totalSizeRead += sizeRead + (uint32_t)sizeof(uint32_t);
 
                 // size is known, now is a good time to create the shape
-                *shape = shape_make_2(shapeSettings->isMutable);
+                *shape = shape_new_2(shapeSettings->isMutable);
                 break;
             }
             case P3S_CHUNK_ID_SHAPE_BLOCKS: {
@@ -1230,7 +1230,7 @@ uint32_t chunk_v6_read_shape(Stream *s,
         Shape *parent = (Shape *)doubly_linked_list_node_pointer(
             doubly_linked_list_node_at_index(shapes, (size_t)parentIndex));
         if (parentIndex >= 0 && parent) {
-            shape_set_parent(*shape, shape_get_root_transform(parent), false);
+            shape_set_parent(*shape, shape_get_transform(parent), false);
             shape_set_local_position(*shape,
                                      localTransform.position.x,
                                      localTransform.position.y,
@@ -1253,14 +1253,14 @@ uint32_t chunk_v6_read_shape(Stream *s,
     }
 
     if (name != NULL) {
-        transform_set_name(shape_get_root_transform(*shape), name);
+        transform_set_name(shape_get_transform(*shape), name);
         free(name);
         name = NULL;
     }
 
     if (hasCustomCollisionBox) {
         RigidBody *rb;
-        transform_ensure_rigidbody(shape_get_root_transform(*shape),
+        transform_ensure_rigidbody(shape_get_transform(*shape),
                                    RigidbodyMode_Static,
                                    PHYSICS_GROUP_DEFAULT_OBJECT,
                                    PHYSICS_COLLIDESWITH_DEFAULT_OBJECT,
@@ -1270,7 +1270,7 @@ uint32_t chunk_v6_read_shape(Stream *s,
         rigidbody_set_collider(rb, &newCollider, true);
     }
 
-    Transform *const root = shape_get_root_transform(*shape);
+    Transform *const root = shape_get_transform(*shape);
     if (root) {
         transform_set_hidden_self(root, isHiddenSelf == 1);
     }
@@ -1430,7 +1430,7 @@ bool chunk_v6_shape_create_and_write_uncompressed_buffer(const Shape *shape,
     bool hasCustomCollisionBox = collider != NULL && rigidbody_is_collider_custom_set(rb);
 
     // is hidden
-    Transform *t = shape_get_root_transform(shape);
+    Transform *t = shape_get_transform(shape);
     uint8_t isHidden = transform_is_hidden_self(t) ? 1 : 0;
 
     // get palette chunk, if not sharing palette w/ root shape
@@ -1444,7 +1444,7 @@ bool chunk_v6_shape_create_and_write_uncompressed_buffer(const Shape *shape,
                                                                &paletteMapping);
     }
 
-    const char *name = transform_get_name(shape_get_root_transform(shape));
+    const char *name = transform_get_name(shape_get_transform(shape));
     uint8_t nameLen = 0;
     if (name != NULL) {
         nameLen = (uint8_t)strlen(name);
@@ -1994,7 +1994,7 @@ bool create_shape_buffers(DoublyLinkedList *shapesBuffers,
     shapeParentId = *shapeId;
     (*shapeId)++;
 
-    DoublyLinkedListNode *n = transform_get_children_iterator(shape_get_root_transform(shape));
+    DoublyLinkedListNode *n = transform_get_children_iterator(shape_get_transform(shape));
     Transform *child = NULL;
     while (n != NULL) {
         child = (Transform *)(doubly_linked_list_node_pointer(n));

--- a/core/serialization_vox.c
+++ b/core/serialization_vox.c
@@ -801,7 +801,7 @@ enum serialization_vox_error serialization_vox_load(Stream *s,
     }
 
     // create Shape
-    *out = shape_make_2(isMutable);
+    *out = shape_new_2(isMutable);
     shape_set_palette(*out, color_palette_new(colorAtlas), false);
 
     stream_set_cursor_position(s, blocksPosition);

--- a/core/shape.h
+++ b/core/shape.h
@@ -64,9 +64,9 @@ typedef uint8_t ShapeDrawMode;
 #define SHAPE_DRAWMODE_GREY 4
 #define SHAPE_DRAWMODE_GRID 8
 
-Shape *shape_make(void);
-Shape *shape_make_2(const bool isMutable);
-Shape *shape_make_copy(Shape *const origin);
+Shape *shape_new(void);
+Shape *shape_new_2(const bool isMutable);
+Shape *shape_new_copy(Shape *const s);
 
 /// Returns false if retain fails
 bool shape_retain(Shape *const shape);
@@ -241,7 +241,7 @@ bool shape_set_parent(Shape *s, Transform *parent, const bool keepWorld);
 /// for external usage i.e. for shapes that exist as a lua Shape, transform removal needs to be
 /// registered in scene, see lua_object for examples
 bool shape_remove_parent(Shape *s, const bool keepWorld);
-Transform *shape_get_root_transform(const Shape *s);
+Transform *shape_get_transform(const Shape *s);
 uint32_t shape_count_shape_descendants(const Shape *s);
 DoublyLinkedListNode *shape_get_transform_children_iterator(const Shape *s);
 

--- a/core/tests/test_shape.h
+++ b/core/tests/test_shape.h
@@ -78,7 +78,7 @@
 // shape_get_model_matrix
 // shape_set_parent
 // shape_remove_parent
-// shape_get_root_transform
+// shape_get_transform
 // shape_get_pivot_transform
 // shape_move_children
 // shape_count_shape_descendants
@@ -142,7 +142,7 @@
 
 // check default values
 void test_shape_make(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     int3 box_size = {1, 1, 1};
 
     TEST_CHECK(shape_get_palette((const Shape *)s) == NULL);
@@ -159,14 +159,14 @@ void test_shape_make(void) {
 
 // check that the copy is independant from the source
 void test_shape_make_copy(void) {
-    Shape *src = shape_make();
+    Shape *src = shape_new();
     shape_set_lua_mutable(src, true);
     {
         ColorAtlas *atlas = color_atlas_new();
         TEST_ASSERT(atlas != NULL);
         shape_set_palette(src, color_palette_new(atlas), false);
     }
-    Shape *copy = shape_make_copy(src);
+    Shape *copy = shape_new_copy(src);
 
     TEST_CHECK(shape_is_lua_mutable(copy));
 
@@ -179,7 +179,7 @@ void test_shape_make_copy(void) {
 
 // check that we can retain a shape
 void test_shape_retain(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     // Transform *t = transform_utils_make_with_shape(s);
 
     bool ok = shape_retain((Shape *const)s);
@@ -195,7 +195,7 @@ void test_shape_retain(void) {
 
 // check that shape_release does not crash
 void test_shape_release(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     // Transform *t = transform_utils_make_with_shape(s);
     shape_retain((Shape *const)s);
 
@@ -205,7 +205,7 @@ void test_shape_release(void) {
 
 // check for coherent id
 void test_shape_get_id(void) {
-    const Shape *s = shape_make();
+    const Shape *s = shape_new();
     const uint16_t id = shape_get_id(s);
 
     TEST_CHECK(id < 1000);
@@ -215,7 +215,7 @@ void test_shape_get_id(void) {
 
 // check that shape's palette atlas is the one provided
 void test_shape_get_palette(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     // const SHAPE_COLOR_INDEX_INT_T idx = 5;
     // const SHAPE_COORDS_INT_T x = 1, y = 2, z = 3;
     ColorAtlas *atlas = color_atlas_new();
@@ -230,7 +230,7 @@ void test_shape_get_palette(void) {
 
 // check that the block is removed (air)
 void test_shape_remove_block(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     const SHAPE_COLOR_INDEX_INT_T idx = 5;
     const SHAPE_COORDS_INT_T x = 1, y = 2, z = 3;
     {
@@ -251,7 +251,7 @@ void test_shape_remove_block(void) {
 
 // check that the box is coherent
 void test_shape_get_bounding_box_size(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     {
         ColorAtlas *atlas = color_atlas_new();
         TEST_ASSERT(atlas != NULL);
@@ -270,7 +270,7 @@ void test_shape_get_bounding_box_size(void) {
 
 // same tests as test_shape_get_bounding_box_size
 void test_shape_get_model_aabb(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     {
         ColorAtlas *atlas = color_atlas_new();
         TEST_ASSERT(atlas != NULL);
@@ -290,7 +290,7 @@ void test_shape_get_model_aabb(void) {
 
 // check that the fullname is the one we provided
 void test_shape_set_fullname(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     const char *name = "shape_name";
     shape_set_fullname(s, name);
 
@@ -302,7 +302,7 @@ void test_shape_set_fullname(void) {
 
 // same test as test_shape_set_fullname
 void test_shape_get_fullname(void) {
-    Shape *s = shape_make();
+    Shape *s = shape_new();
     const char *name = "shape_name";
     shape_set_fullname(s, name);
 
@@ -330,7 +330,7 @@ void test_shape_addblock_1(void) {
     TEST_ASSERT(sc != NULL);
 
     // create a mutable shape having an octree
-    Shape *sh = shape_make_2(true); // isMutable
+    Shape *sh = shape_new_2(true); // isMutable
     TEST_ASSERT(sh != NULL);
 
     {
@@ -427,7 +427,7 @@ void test_shape_addblock_2(void) {
     TEST_ASSERT(sc != NULL);
 
     // create a mutable shape having an octree
-    Shape *sh = shape_make_2(true); // isMutable
+    Shape *sh = shape_new_2(true); // isMutable
     TEST_ASSERT(sh != NULL);
 
     {
@@ -516,7 +516,7 @@ void test_shape_addblock_3(void) {
     Scene *sc = scene_new(NULL);
     TEST_CHECK(sc != NULL);
 
-    Shape *sh = shape_make();
+    Shape *sh = shape_new();
     TEST_CHECK(sh != NULL);
 
     // add block 1

--- a/core/transform.h
+++ b/core/transform.h
@@ -79,6 +79,8 @@ typedef Transform **Transform_Array;
 /// MARK: - Lifecycle -
 Transform *transform_new(TransformType type);
 Transform *transform_new_with_ptr(TransformType type, void *ptr, pointer_free_function ptrFreeFn);
+Transform *transform_new_copy(const Transform *t);
+void transform_copy(Transform *dst, const Transform *src);
 void transform_init_ID_thread_safety(void);
 uint16_t transform_get_id(const Transform *t);
 /// Increases ref count and returns false if the retain count can't be increased
@@ -122,7 +124,7 @@ bool transform_set_parent(Transform *const t, Transform *parent, bool keepWorld)
 bool transform_remove_parent(Transform *t, bool keepWorld);
 Transform *transform_get_parent(Transform *t);
 bool transform_is_parented(Transform *t);
-DoublyLinkedListNode *transform_get_children_iterator(Transform *t);
+DoublyLinkedListNode *transform_get_children_iterator(const Transform *t);
 Transform_Array transform_get_children_copy(Transform *t, size_t *count);
 size_t transform_get_children_count(Transform *t);
 void *transform_get_ptr(Transform *const t);
@@ -236,6 +238,7 @@ void transform_utils_box_fit_recurse(Transform *t,
                                      bool applyTransaction);
 void transform_utils_set_mtx(Transform *t, const Matrix4x4 *mtx);
 bool transform_utils_has_shadow(const Transform *t);
+Transform* transform_utils_copy_recurse(const Transform *t);
 
 // MARK: - Misc. -
 void transform_set_animations_enabled(Transform *const t, const bool enabled);

--- a/core/world_text.c
+++ b/core/world_text.c
@@ -148,6 +148,35 @@ WorldText *world_text_new(void) {
     return wt;
 }
 
+WorldText *world_text_new_copy(const WorldText *wt) {
+    WorldText *copy = world_text_new();
+    transform_copy(copy->transform, wt->transform);
+    copy->text = string_new_copy(wt->text);
+    if (wt->drawmodes != NULL) {
+        copy->drawmodes = (WorldTextDrawmodes*)malloc(sizeof(WorldTextDrawmodes));
+        memcpy(copy->drawmodes, wt->drawmodes, sizeof(WorldTextDrawmodes));
+    }
+    copy->anchorX = wt->anchorX;
+    copy->anchorY = wt->anchorY;
+    copy->color = wt->color;
+    copy->bgColor = wt->bgColor;
+    copy->width = wt->width;
+    copy->height = wt->height;
+    copy->maxWidth = wt->maxWidth;
+    copy->maxDistance = wt->maxDistance;
+    copy->padding = wt->padding;
+    copy->fontSize = wt->fontSize;
+    copy->layers = wt->layers;
+    copy->options = wt->options;
+    copy->type = wt->type;
+    copy->fontIdx = wt->fontIdx;
+    copy->sortOrder = wt->sortOrder;
+    copy->weight = wt->weight;
+    copy->slant = wt->slant;
+
+    return copy;
+}
+
 void world_text_release(WorldText *wt) {
     transform_release(wt->transform);
 }

--- a/core/world_text.h
+++ b/core/world_text.h
@@ -41,6 +41,7 @@ typedef enum {
 } TextAlignment;
 
 WorldText *world_text_new(void);
+WorldText *world_text_new_copy(const WorldText *wt);
 void world_text_release(WorldText *wt); // releases transform
 
 Transform *world_text_get_transform(const WorldText *wt);

--- a/lua/modules/cubzh.lua
+++ b/lua/modules/cubzh.lua
@@ -420,7 +420,7 @@ function titleScreen()
 		didResizeFunction = function()
 			layoutCamera({ noAnimation = true })
 			-- local box = Box()
-			-- box:Fit(logo, { recursive = true })
+			-- box:Fit(logo, { recurse = true })
 			-- Camera:FitToScreen(box, 0.8)
 		end
 

--- a/lua/modules/massloading.lua
+++ b/lua/modules/massloading.lua
@@ -80,7 +80,7 @@ massLoading.load = function(_, collection, config)
 	end
 
 	local function loadObject(template, data)
-		config.onLoad(Shape(template, { includeChildren = true }), data)
+		config.onLoad(Shape(template, { recurse = true }), data)
 		loadedNextObject()
 	end
 

--- a/lua/modules/transformgizmo.lua
+++ b/lua/modules/transformgizmo.lua
@@ -120,7 +120,7 @@ end
 
 function getCenter(target)
 	local box = Box()
-	box:Fit(target, { recursive = true })
+	box:Fit(target, { recurse = true })
 	return box.Center
 end
 

--- a/lua/modules/ui_avatar.lua
+++ b/lua/modules/ui_avatar.lua
@@ -201,7 +201,7 @@ uiavatar.getHead = function(_, usernameOrId, size, uikit, config)
 	end
 
 	if cachedHead ~= nil then
-		local headCopy = Shape(cachedHead, { includeChildren = true })
+		local headCopy = Shape(cachedHead, { recurse = true })
 		headCopy.setEyes = cachedHead.setEyes
 
 		local uiHead = ui:createShape(headCopy, { spherized = true })
@@ -216,7 +216,7 @@ uiavatar.getHead = function(_, usernameOrId, size, uikit, config)
 		head, requests = avatar:getPlayerHead({ usernameOrId = usernameOrId })
 		-- headCache[usernameOrId] = head
 
-		-- local headCopy = Shape(head, { includeChildren = true })
+		-- local headCopy = Shape(head, { recurse = true })
 		-- headCopy.setEyes = head.setEyes
 
 		local uiHead = ui:createShape(head, { spherized = false })

--- a/lua/modules/uikit.lua
+++ b/lua/modules/uikit.lua
@@ -1016,7 +1016,7 @@ function createUI(system)
 		node.pivot.LocalRotation = Number3.Zero
 
 		local aabb = Box()
-		aabb:Fit(node.shape, { recursive = true })
+		aabb:Fit(node.shape, { recurse = true })
 
 		node.object.LocalScale = backupScale -- restore node scale
 

--- a/lua/modules/world.lua
+++ b/lua/modules/world.lua
@@ -629,7 +629,7 @@ end
 -- Load a map into the world
 local function loadMap(d, n, didLoad)
 	Object:Load(d, function(j)
-		local map = MutableShape(j, { includeChildren = true })
+		local map = MutableShape(j, { recurse = true })
 		loaded.map = map
 
 		map.Scale = n or 5


### PR DESCRIPTION
This PR,
- adds a universal `o:Copy({ recurse=false })`
- improves on the recursion lock to handle nested `o:Recurse()` calls